### PR TITLE
SBT 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Provides:
 
 To include this module in your Lift project, update your `libraryDependencies` in `build.sbt` to include:
 
+*Lift 2.6.x* for Scala 2.9 and 2.10:
+
+    "net.liftmodules" %% "widgets_2.6" % "1.3"
+
 *Lift 2.5.x* for Scala 2.9 and 2.10:
 
     "net.liftmodules" %% "widgets_2.5" % "1.3"

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,13 @@ organization := "net.liftmodules"
 
 version := "1.4-SNAPSHOT"
 
-liftVersion <<= liftVersion ?? "2.5"
+liftVersion <<= liftVersion ?? "2.6-SNAPSHOT"
 
 liftEdition <<= liftVersion apply { _.substring(0,3) }
 
-name <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
+moduleName <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.10.3"
 
 crossScalaVersions := Seq("2.10.0", "2.9.2", "2.9.1-1", "2.9.1")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.12.3
-
+sbt.version=0.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ resolvers += Resolver.url("sbt-plugin-releases",
 
 resolvers += Classpaths.typesafeResolver
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")


### PR DESCRIPTION
SBT 0.13 requires us to use `moduleName` and not `name`in _build.sbt_ for forming the widgets_2.6 style name for artifacts.

If we're OK with this, I'll apply this around the other modules in due course.

Also:
- Default is now to build against Lift 2.6
- Updated IDE plugin versions
