### PR TITLE
Lift 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,13 +36,10 @@ publishTo := (version.value.endsWith("SNAPSHOT") match {
  	case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
 })
 
-// For local deployment:
-
-credentials += Credentials( file("sonatype.credentials") )
-
-// For the build server:
-
-credentials += Credentials( file("/private/liftmodules/sonatype.credentials") )
+credentials ++= (for {
+  username <- Option(System.getenv().get("SONATYPE_USERNAME"))
+  password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
+} yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,20 @@
+import LiftModule.{liftVersion, liftEdition}
+
 name := "widgets"
 
 organization := "net.liftmodules"
 
-version := "1.4-SNAPSHOT"
+version := "1.4.0-SNAPSHOT"
 
-liftVersion <<= liftVersion ?? "2.6-SNAPSHOT"
+liftVersion := "3.0.1"
 
-liftEdition <<= liftVersion apply { _.substring(0,3) }
+liftEdition := (liftVersion apply { _.substring(0,3) }).value
 
-moduleName <<= (name, liftEdition) { (n, e) =>  n + "_" + e }
+moduleName := name.value + "_" + liftEdition.value
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.12.1"
 
-crossScalaVersions := Seq("2.11.1", "2.10.4", "2.9.2", "2.9.1-1", "2.9.1")
+crossScalaVersions := Seq("2.12.1", "2.11.8")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
@@ -20,31 +22,19 @@ resolvers += "CB Central Mirror" at "http://repo.cloudbees.com/content/groups/pu
 
 resolvers += "Java.net Maven2 Repository" at "http://download.java.net/maven/2/"
 
-libraryDependencies <++= liftVersion { v =>
-  "net.liftweb" %% "lift-webkit" % v % "provided" ::
-  Nil
-}
+libraryDependencies += "net.liftweb" %% "lift-webkit" % liftVersion.value % "provided"
 
-libraryDependencies <++= scalaVersion { sv =>
-  "ch.qos.logback" % "logback-classic" % "1.1.2" % "provided" ::
+libraryDependencies ++=
+  "ch.qos.logback" % "logback-classic" % "1.1.8" % "provided" ::
   "log4j" % "log4j" % "1.2.17" % "provided" ::
-   (sv match {
-     case "2.9.2" | "2.9.1" | "2.9.1-1" => "org.specs2" %% "specs2" % "1.12.3" % "test"
-     case _ =>  "org.specs2" %% "specs2" % "2.3.12" % "test"
-   })  ::
-   (sv match {
-     case "2.9.2" | "2.9.1" | "2.9.1-1" => "org.scalacheck" %% "scalacheck" % "1.10.1" % "test"
-     case _ => "org.scalacheck" %% "scalacheck" % "1.11.4" % "test"
-   })  ::
+  "org.specs2" %% "specs2-core" % "3.8.6" % "test" ::
+  "org.scalacheck" %% "scalacheck" % "1.13.4" % "test" ::
   Nil
-}
 
-publishTo <<= version { _.endsWith("SNAPSHOT") match {
+publishTo := (version.value.endsWith("SNAPSHOT") match {
  	case true  => Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
  	case false => Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-  }
- }
-
+})
 
 // For local deployment:
 
@@ -82,4 +72,3 @@ pomExtra := (
 	 	</developer>
 	 </developers>
  )
-

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -1,13 +1,7 @@
 import sbt._
 import sbt.Keys._
 
-object LiftModuleBuild extends Build {
-
-  val liftVersion = SettingKey[String]("liftVersion", "Full version number of the Lift Web Framework")
-
-  val liftEdition = SettingKey[String]("liftEdition", "Lift Edition (short version number to append to artifact name)")
-
-  val project = Project("LiftModule", file("."))
-
+object LiftModule {
+  val liftVersion = settingKey[String]("Lift Web Framework full version number")
+  val liftEdition = settingKey[String]("Lift Edition (such as 2.6 or 3.0)")
 }
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.13


### PR DESCRIPTION
Updated to use Lift 3.0.1 and migrated sbt format to 0.13.13. Scala versions before 2.11 have been dropped.