### PR TITLE
Complete 1.4.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ Provides:
 
 To include this module in your Lift project, add the following to `build.sbt`:
 
-    libraryDependencies += "net.liftmodules" %% "widgets_3.0" % "1.4.0"
+    libraryDependencies += "net.liftmodules" %% "widgets_3.0" % "<VERSION>"
+
+..but replacing `<VERSION>` with one of the "Module Version" numbers listed in the table below (e.g., to end up with "1.4.1").
 
 Releases
 ========
 
 | Lift Version | Scala Version | Module Version |
 |--------------|---------------|----------------|
-| 3.0.x        | 2.12, 2.11    | 1.4.0          |
+| 3.0.x        | 2.12    | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.liftmodules/widgets_3.0_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.liftmodules/widgets_3.0_2.12) |
+| 3.0.x        | 2.11    | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.liftmodules/widgets_3.0_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.liftmodules/widgets_3.0_2.11) |
 | 2.6.x        | 2.10, 2.9     | 1.3            |
 | 2.5.x        | 2.10, 2.9     | 1.3            |
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "widgets"
 
 organization := "net.liftmodules"
 
-version := "1.4.0-SNAPSHOT"
+version := "1.4.1-SNAPSHOT"
 
 liftVersion := "3.0.1"
 


### PR DESCRIPTION
- Bumped the module version number; and 
- now ask Maven Central to tell us the latest version rather than hard-code it in the README. 

It'll look like this:

![readme md - grip 2017-01-12 14-45-31](https://cloud.githubusercontent.com/assets/102661/21894089/d2720ef2-d8d5-11e6-957c-6d18b00f370d.png)

(Ok it'll show 1.4.1 once the release propagates out)