### PR TITLE
Housekeeping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import LiftModule.{liftVersion, liftEdition}
+val liftVersion = settingKey[String]("Lift Web Framework full version number")
+val liftEdition = settingKey[String]("Lift Edition (such as 2.6 or 3.0)")
 
 name := "widgets"
 
@@ -12,9 +13,8 @@ liftEdition := (liftVersion apply { _.substring(0,3) }).value
 
 moduleName := name.value + "_" + liftEdition.value
 
-scalaVersion := "2.12.1"
-
-crossScalaVersions := Seq("2.12.1", "2.11.8")
+crossScalaVersions := Seq("2.12.2", "2.11.11")
+scalaVersion := crossScalaVersions.value.head
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
@@ -25,10 +25,8 @@ resolvers += "Java.net Maven2 Repository" at "http://download.java.net/maven/2/"
 libraryDependencies += "net.liftweb" %% "lift-webkit" % liftVersion.value % "provided"
 
 libraryDependencies ++=
-  "ch.qos.logback" % "logback-classic" % "1.1.8" % "provided" ::
+  "ch.qos.logback" % "logback-classic" % "1.2.3" % "provided" ::
   "log4j" % "log4j" % "1.2.17" % "provided" ::
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test" ::
-  "org.scalacheck" %% "scalacheck" % "1.13.4" % "test" ::
   Nil
 
 publishTo := (version.value.endsWith("SNAPSHOT") match {

--- a/project/LiftModule.scala
+++ b/project/LiftModule.scala
@@ -1,7 +1,0 @@
-import sbt._
-import sbt.Keys._
-
-object LiftModule {
-  val liftVersion = settingKey[String]("Lift Web Framework full version number")
-  val liftEdition = settingKey[String]("Lift Edition (such as 2.6 or 3.0)")
-}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
Migrated remaining project/*.scala code to build.sbt, updated sbt and scala versions, updated logback version (security vulernability prior to 1.2.3), and removed unused dependencies.

This module looks good to go for Lift 3.1 publishing. 